### PR TITLE
Fix the corner case of calculating SOA

### DIFF
--- a/metrics/soa.py
+++ b/metrics/soa.py
@@ -228,7 +228,7 @@ class SemanticObjectAccuracy(Metric):
                 accuracy.append(-1)
             else:
                 accuracy.append(
-                    sum([1. for x in preds if x in labels]) / len(labels))
+                    sum([1. for x in set(preds) if x in labels]) / len(labels))
         accuracy = torch.Tensor(accuracy)
         if 0 < division_by_zero:
             print(f"warning: {division_by_zero} samples have no detection.")


### PR DESCRIPTION
In [this line](https://github.com/naver-ai/mid.metric/blob/d22852d558562a352462752492df68a1045fd6f3/metrics/soa.py#L231),

https://github.com/naver-ai/mid.metric/blob/d22852d558562a352462752492df68a1045fd6f3/metrics/soa.py#L231

The SOA metric might be over-estimated if `preds` have multiple elements with the same label when multiple detected objects share the same label. The call `set()` for the `preds` would solve this issue. However, I confirm that this benchmark dataset has no such case.